### PR TITLE
Added handling for signals for empty ads

### DIFF
--- a/android/src/main/java/com/netcetera/reactnative/adtech/AdtechView.java
+++ b/android/src/main/java/com/netcetera/reactnative/adtech/AdtechView.java
@@ -539,11 +539,11 @@ class AdtechView extends RelativeLayout {
         if (signals == null || signals.length == 0) return true;
         if (signalsForEmptyAds == null || signalsForEmptyAds.isEmpty()) return true;
 
-        Boolean shouldShow = false;
+        Boolean shouldShow = true;
 
         for (int signal : signals) {
             if (signalsForEmptyAds.contains(signal)) {
-                shouldShow = true;
+                shouldShow = false;
                 break;
             }
         }

--- a/android/src/main/java/com/netcetera/reactnative/adtech/AdtechView.java
+++ b/android/src/main/java/com/netcetera/reactnative/adtech/AdtechView.java
@@ -1,6 +1,7 @@
 package com.netcetera.reactnative.adtech;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import android.app.Activity;
 import android.content.Context;
@@ -47,6 +48,7 @@ class AdtechView extends RelativeLayout {
     private Activity activity;
     private String appName;
     private String domain;
+    private List<Integer> signalsForEmptyAds;
 
     private int reactTag;
 
@@ -55,10 +57,16 @@ class AdtechView extends RelativeLayout {
 
     private ArrayList<SizeChangeListener> sizeChangeListeners = new ArrayList<>();
 
-    public AdtechView(Context context, Activity activity, String appName, String domain) {
+    public AdtechView(Context context
+            , Activity activity
+            , String appName
+            , String domain
+            , List<Integer> signalsForEmptyAds) {
         super(context);
         this.appName = appName;
         this.domain = domain;
+        this.signalsForEmptyAds = signalsForEmptyAds;
+
         this.activity = activity;
 
         //activity.getLayoutInflater().inflate(R.layout.add_container, this, true);
@@ -295,7 +303,12 @@ class AdtechView extends RelativeLayout {
 
                     @Override
                     public void onAdSuccessWithSignal(int... signals) {
-                        adSuccess();
+                        Boolean shouldShow = shouldShowAdWithSignals(signals);
+                        if (shouldShow) {
+                            adSuccess();
+                        } else {
+                            adFail();
+                        }
                     }
 
                     void adSuccess() {
@@ -368,12 +381,18 @@ class AdtechView extends RelativeLayout {
             @Override
             public void onAdSuccessWithSignal(int... signals) {
                 super.onAdSuccessWithSignal(signals);
-                adFecthedSuccessfully();
-                adtechInterstitialView.setVisibility(View.VISIBLE);
-                adtechInterstitialView.bringToFront();
-                adtechInterstitialView.requestLayout();
-                adtechInterstitialView.setBackgroundColor(0xd9000000);
 
+                Boolean shouldShow = shouldShowAdWithSignals(signals);
+
+                if (shouldShow) {
+                    adFecthedSuccessfully();
+                    adtechInterstitialView.setVisibility(View.VISIBLE);
+                    adtechInterstitialView.bringToFront();
+                    adtechInterstitialView.requestLayout();
+                    adtechInterstitialView.setBackgroundColor(0xd9000000);
+                } else {
+                    adFetchFailed();
+                }
             }
 
             @Override
@@ -513,5 +532,21 @@ class AdtechView extends RelativeLayout {
         }
 
         return result.toArray(new String[]{});
+    }
+
+    private Boolean shouldShowAdWithSignals(int... signals)
+    {
+        if (signals == null || signals.length == 0) return true;
+        if (signalsForEmptyAds == null || signalsForEmptyAds.isEmpty()) return true;
+
+        Boolean shouldShow = false;
+
+        for (int signal : signals) {
+            if (signalsForEmptyAds.contains(signal)) {
+                shouldShow = true;
+                break;
+            }
+        }
+        return shouldShow;
     }
 }

--- a/android/src/main/java/com/netcetera/reactnative/adtech/AdtechViewManager.java
+++ b/android/src/main/java/com/netcetera/reactnative/adtech/AdtechViewManager.java
@@ -2,7 +2,9 @@ package com.netcetera.reactnative.adtech;
 
 import android.support.annotation.NonNull;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.facebook.infer.annotation.Assertions;
@@ -29,10 +31,12 @@ public class AdtechViewManager
     private static final String TAG = AdtechViewManager.class.getCanonicalName();
     private String appName;
     private String domain;
+    private List<Integer> signalsForEmptyAds;
 
-    public AdtechViewManager(String appName, String domain) {
+    public AdtechViewManager(String appName, String domain, List<Integer> signalsForEmptyAds) {
         this.domain = domain;
         this.appName = appName;
+        this.signalsForEmptyAds = signalsForEmptyAds;
     }
 
     @Override
@@ -139,7 +143,8 @@ public class AdtechViewManager
                 context
                 , context.getCurrentActivity()
                 , appName
-                , domain);
+                , domain
+                , signalsForEmptyAds);
 
         view.addSizeChangeListener(this);
         return view;
@@ -159,6 +164,7 @@ public class AdtechViewManager
                 , context.getCurrentActivity()
                 , ""
                 , ""
+                , new ArrayList<Integer>()
         );
     }
 

--- a/android/src/main/java/com/netcetera/reactnative/adtech/AdtechViewPackage.java
+++ b/android/src/main/java/com/netcetera/reactnative/adtech/AdtechViewPackage.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -14,10 +15,12 @@ public class AdtechViewPackage implements ReactPackage {
 
     private String appName;
     private String domain;
+    private List<Integer> signalsForEmptyAds;
 
-    public AdtechViewPackage(String appName, String domain) {
+    public AdtechViewPackage(String appName, String domain, List<Integer> signalsForEmptyAds) {
         this.appName = appName;
         this.domain = domain;
+        this.signalsForEmptyAds = signalsForEmptyAds != null ? signalsForEmptyAds : new ArrayList<Integer>();
     }
 
     @Override
@@ -29,7 +32,7 @@ public class AdtechViewPackage implements ReactPackage {
     public List<ViewManager> createViewManagers(
             ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
-                new AdtechViewManager(appName, domain)
+                new AdtechViewManager(appName, domain, signalsForEmptyAds)
         );
     }
 }

--- a/ios/AdtechViewManager.h
+++ b/ios/AdtechViewManager.h
@@ -6,4 +6,6 @@
 + (void)setLoggingEnabled:(BOOL)enabled;
 + (BOOL)isLoggingEnabled;
 
++ (void)setSignalsForEmptyAds:(NSArray *)signalsForEmptyAds;
+
 @end

--- a/ios/AdtechViewManager.m
+++ b/ios/AdtechViewManager.m
@@ -21,6 +21,7 @@ RCT_EXPORT_VIEW_PROPERTY(onAdFetchFail, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onInterstitialHidden, RCTDirectEventBlock)
 
 static BOOL isLoggingEnabled = NO;
+static NSArray *signalsForEmptyAdverts = nil;
 
 + (void)setLoggingEnabled:(BOOL)enabled
 {
@@ -32,9 +33,15 @@ static BOOL isLoggingEnabled = NO;
     return isLoggingEnabled;
 }
 
++ (void)setSignalsForEmptyAds:(NSArray *)signalsForEmptyAds
+{
+    signalsForEmptyAdverts = signalsForEmptyAds;
+}
+
 - (UIView *)view
 {
     RNAdtechView *adTechView = [RNAdtechView new];
+    adTechView.signalsForEmptyAds = signalsForEmptyAdverts ? signalsForEmptyAdverts : @[];
     adTechView.delegate = self;
 
     return adTechView;

--- a/ios/RNAdtechView.h
+++ b/ios/RNAdtechView.h
@@ -31,6 +31,8 @@
 @property (nonatomic, copy) RCTDirectEventBlock onAdFetchFail;
 @property (nonatomic, copy) RCTDirectEventBlock onInterstitialHidden;
 
+@property (nonatomic, weak) NSArray *signalsForEmptyAds;
+
 - (void)pause;
 - (void)resume;
 


### PR DESCRIPTION
This pull request adds the capability to check for empty ads if they are signaled from AdTech.
In theory this code should work. The expected signal codes for empty ads should be configured in iOS and Android.

For Android: do it during the module registration (this is an additional constructor parameter)
For iOS: In the application:didLaunchWithOptions: use the static method to declare the signals:

[AdtechViewManager setSignalsForEmptyAds:@[<list of signals here>]];

This is not ready for merge as it is not tested yet. Once customers configure such data, this should be tested and if working as expected, merged.